### PR TITLE
JSON RPC 2.0 notifications have undefined id elements

### DIFF
--- a/doc/notes.org
+++ b/doc/notes.org
@@ -4,3 +4,4 @@ Models of network traffic Websocket / REST
 
 Moved to <https://github.com/emotiq/emotiq/tree/dev/src/model>. 
 
+*<2018-07-10 Tue 15:31>w

--- a/src/app/shared/ws/client.js
+++ b/src/app/shared/ws/client.js
@@ -28,7 +28,7 @@ function onMessage(evt) {
   let data = JSON.parse(evt.data);
   let id = data.id;
   console.log(evt.data);
-  if (id !== null) {
+  if (id !== undefined) {
     if (messages[id]) {
       data.result ?
         messages[id].next(data.result) && messages[id].complete() :


### PR DESCRIPTION
In order to have the devops tooling using the Python websockets RPC code, we need to tighten the protocol so that RPC messages no longer have `null` elements, but rather are missing the JSON dictionary key.  

In order for this to work with the `emotiq`, one needs a new release of the binaries.  This hasn't been done yet, but when it is done, the wallet will need this change to work with the new protocol.